### PR TITLE
chore(setup): added lint staged config file

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -6,7 +6,11 @@ const buildEslintCommand = (filenames) =>
     .join(" --file ")}`
 
 const config = {
-  "src/**/*.{ts,tsx}": ["yarn prettier", buildEslintCommand],
+  "src/**/*.{ts,tsx}": [
+    () => "yarn type-check",
+    "yarn prettier",
+    buildEslintCommand,
+  ],
 }
 
 export default config

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,12 @@
+import path from "path"
+
+const buildEslintCommand = (filenames) =>
+  `next lint --file ${filenames
+    .map((f) => path.relative(process.cwd(), f))
+    .join(" --file ")}`
+
+const config = {
+  "src/**/*.{ts,tsx}": ["yarn prettier", buildEslintCommand],
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "type-check": "tsc --project tsconfig.json --pretty --noEmit",
     "seed": "tsx prisma/seeds/participants.ts",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -42,11 +42,5 @@
     "lint-staged": "13.2.2",
     "prisma": "4.16.0",
     "tsx": "3.12.7"
-  },
-  "lint-staged": {
-    "src/**/*.{ts,tsx}": [
-      "yarn prettier",
-      "yarn lint"
-    ]
   }
 }


### PR DESCRIPTION
O `next lint` (eslint) estava quebrando na execução do `lint-staged`. O problema encontrado é o mesmo relatado aqui: https://github.com/vercel/next.js/issues/33096.

O erro que eu estava recebendo:
![Captura de tela de 2023-06-28 12-55-17](https://github.com/codeinthedarkbrasil/manage-citd/assets/45916330/6d98e668-8677-4b6d-b546-86982a5916f4)

Solução: https://nextjs.org/docs/pages/building-your-application/configuring/eslint#lint-staged

Aproveitei também e configurei o `type-check` no `lint-staged`: https://github.com/okonet/lint-staged#example-run-tsc-on-changes-to-typescript-files-but-do-not-pass-any-filename-arguments

@fdaciuk @vmarcosp 