### PR TITLE
fix: hide input file behind csv upload button 

### DIFF
--- a/src/app/events/[event]/page.tsx
+++ b/src/app/events/[event]/page.tsx
@@ -142,18 +142,17 @@ export default function Event({ params }: EventProps) {
         </h1>
         <nav>
           <ul className="flex gap-3">
-            <li className="relative">
-              <form action={upload} className="absolute">
+            <li className="group relative flex w-[130px] overflow-hidden ">
+              <form action={upload} className="absolute top-[6px] z-[hidden]">
                 <input
                   type="file"
                   name="file"
-                  className="text-neutral-900"
+                  className="h-[30px]  text-[16px] text-neutral-100  "
                   onChange={handleFileUpload}
                 />
-
                 <input type="hidden" name="event" value={event} />
               </form>
-              <Button variant="text">Importar CSV</Button>
+              <Button variant="file" >Importar CSV</Button>
             </li>
             <li>
               <Modal>

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -24,6 +24,7 @@ const buttonVariants = cva(
       variant: {
         primary: "bg-primary-100 text-neutral-100 hover:bg-primary-100/80",
         text: "text-primary-100 hover:bg-primary-100 hover:text-neutral-100",
+        file: "pointer-events-none absolute z-[base] w-full bg-neutral-100 text-primary-100 group-hover:cursor-pointer group-hover:bg-primary-100 group-hover:text-neutral-100",
       },
       size: {
         sm: "h-[42px] rounded-1 px-2",


### PR DESCRIPTION
Improve style for CSV upload #32
A new variant for the button, named "file", were included.
A "pointer-events-none" was placed on the button to allow the drag-n-drop of the file, it was also adjusted, as best I could, the input file behind the button. 
Tested on Chrome